### PR TITLE
support lmcache prefetch

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -618,6 +618,11 @@ class Scheduler(
                 )
             )
         )
+        self.enable_lmcache_prefetch = (
+            server_args.enable_lmcache_prefetch
+            and hasattr(self.tree_cache, "lmcache_connector")
+            and (self.tree_cache.lmcache_connector is not None)
+        )
 
     def init_profier(self):
         self.torch_profiler = None
@@ -1217,6 +1222,8 @@ class Scheduler(
             self.disagg_decode_prealloc_queue.add(req)
         else:
             self.waiting_queue.append(req)
+            if self.enable_lmcache_prefetch:
+                self.tree_cache.lmcache_prefetch(req.origin_input_ids)
 
     def _extend_requests_to_queue(self, reqs: List[Req], is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -146,6 +146,8 @@ class RadixCache(BasePrefixCache):
             self.shutdown_event = threading.Event()
             self.writer_thread = threading.Thread(target=self._lmcache_writer_worker)
             self.writer_thread.start()
+        else:
+            self.lmcache_connector = None
 
     ##### Public API #####
 
@@ -459,6 +461,14 @@ class RadixCache(BasePrefixCache):
                 continue
             except Exception as e:
                 logger.error(f"Error in LMCache writer thread: {e}", exc_info=True)
+
+    def lmcache_prefetch(
+        self,
+        tokens: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+    ):
+        if self.lmcache_connector:
+            self.lmcache_connector.prefetch(tokens, mask)
 
     def _match_prefix_helper(self, node: TreeNode, key: List):
         node.last_access_time = time.monotonic()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -245,6 +245,7 @@ class ServerArgs:
     
     # For LMCache
     enable_lmcache_connector: bool = False
+    enable_lmcache_prefetch: bool = False
 
     def __post_init__(self):
         # Expert parallelism
@@ -1637,6 +1638,11 @@ class ServerArgs:
             "--enable-lmcache-connector",
             action="store_true",
             help="Enable the LMCache connector.",
+        )
+        parser.add_argument(
+            "--enable-lmcache-prefetch",
+            action="store_true",
+            help="Enable the LMCache prefetch.",
         )
 
     @classmethod


### PR DESCRIPTION
Prefetch is very useful for multi level cache. When to call prefetch: in VLLM/sglang, when scheduler add request, the prefetch can be called. Since requests are waiting to be precessed in scheduler waiting queue, when the requests are waiting, they can be prefetched from low speed cache storage, such as disk.