### PR TITLE
Fix cuda graph config dataclass access

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -56,8 +56,6 @@ def set_default_server_args(args: "ServerArgs"):
         args.page_size = 128
 
     # NPU memory settings
-    from sglang.srt.model_executor.cuda_graph_config import Phase
-
     decode = args.cuda_graph_config.decode
     npu_mem = get_npu_memory_capacity()
     if npu_mem <= 32 * 1024:
@@ -65,21 +63,21 @@ def set_default_server_args(args: "ServerArgs"):
         # (chunked_prefill_size 4k, max_bs 16 if tp < 4 else 64)
         if args.chunked_prefill_size is None:
             args.chunked_prefill_size = 4 * 1024
-        if decode["max_bs"] is None:
+        if decode.max_bs is None:
             if args.tp_size < 4:
-                decode["max_bs"] = 16
+                decode.max_bs = 16
             else:
-                decode["max_bs"] = 64
+                decode.max_bs = 64
     elif npu_mem <= 64 * 1024:
         # Ascend 910B1,910B2,910B2C,910B3,910_9391,910_9392,910_9381,910_9382,910_9372,910_9362
         # (chunked_prefill_size 8k, max_bs 64 if tp < 4 else 256)
         if args.chunked_prefill_size is None:
             args.chunked_prefill_size = 8 * 1024
-        if decode["max_bs"] is None:
+        if decode.max_bs is None:
             if args.tp_size < 4:
-                decode["max_bs"] = 64
+                decode.max_bs = 64
             else:
-                decode["max_bs"] = 256
+                decode.max_bs = 256
 
     # NPU does not support CustomAllReduce
     args.disable_custom_all_reduce = True
@@ -219,7 +217,7 @@ def init_zbal(world_size, gpu_id, world_rank, do_check=True):
         gva_is_inited = True
 
         if do_check and not ret:
-            logger.error(f"[ZBAL] zbal init failed!")
+            logger.error("[ZBAL] zbal init failed!")
             sys.exit(-1)
 
         return ret
@@ -274,7 +272,7 @@ def lazy_init_zbal_gva_mem(
 
     gva_is_inited = True
     if do_check and not res:
-        logger.error(f"[ZBAL] zbal lazy init failed!")
+        logger.error("[ZBAL] zbal lazy init failed!")
         sys.exit(-1)
     return res
 

--- a/python/sglang/srt/kv_canary/capacities.py
+++ b/python/sglang/srt/kv_canary/capacities.py
@@ -4,8 +4,6 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from sglang.srt.model_executor.cuda_graph_config import Phase
-
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
@@ -65,8 +63,10 @@ class CanaryLaunchCapacities:
                 f"kv-canary: pool_slot_count must be positive, got {pool_slot_count}"
             )
 
-        decode_cg_cfg = (server_args.cuda_graph_config or {}).get(Phase.DECODE) or {}
-        cuda_graph_max_bs = decode_cg_cfg.get("max_bs") or 0
+        cuda_graph_config = server_args.cuda_graph_config
+        cuda_graph_max_bs = (
+            cuda_graph_config.decode.max_bs if cuda_graph_config is not None else 0
+        ) or 0
         if cuda_graph_max_bs < 0:
             raise ValueError(
                 f"kv-canary: cuda_graph_max_bs must be non-negative, got {cuda_graph_max_bs}"

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Union
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.speculative.spec_utils import spec_need_hidden_states
 from sglang.srt.utils import is_cuda, is_hip, is_npu
 
@@ -30,8 +30,11 @@ def decide_needs_cpu_seq_lens(
     if server_args.enable_two_batch_overlap:
         # FIXME: support TBO without seq lens cpu value
         return True
-    prefill_cfg = (server_args.cuda_graph_config or {}).get(Phase.PREFILL) or {}
-    if prefill_cfg.get("backend") == Backend.TC_PIECEWISE:
+    cuda_graph_config = server_args.cuda_graph_config
+    if (
+        cuda_graph_config is not None
+        and cuda_graph_config.prefill.backend == Backend.TC_PIECEWISE
+    ):
         # FIXME: support PCG without seq lens cpu value
         return True
     # Skip unset slots (e.g. draft_extend_attn_backend on some spec configs);

--- a/python/sglang/srt/model_executor/cuda_graph_backend/tc_piecewise_cudagraph_backend.py
+++ b/python/sglang/srt/model_executor/cuda_graph_backend/tc_piecewise_cudagraph_backend.py
@@ -93,11 +93,9 @@ class TcPiecewiseCudaGraphBackend(BaseCudaGraphBackend):
         the config, and registers the MoE A2A split-op when DeepEP /
         Mooncake is in use.
         """
-        from sglang.srt.model_executor.cuda_graph_config import Phase
-
         prefill = server_args.cuda_graph_config.prefill
-        num_tokens = prefill["bs"]
-        compiler = prefill["tc_compiler"]
+        num_tokens = prefill.bs
+        compiler = prefill.tc_compiler
         assert num_tokens is not None, "cuda_graph_config[prefill].bs is not set"
         assert compiler in _VALID_COMPILERS, (
             f"By now, only {_VALID_COMPILERS} are supported for the "

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -48,7 +48,6 @@ from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUN
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.model_executor.cuda_graph_config import (
     ALLOWED_BACKENDS_PER_PHASE,
-    ALLOWED_KEYS_PER_PHASE,
     Backend,
     CudaGraphConfig,
     Phase,
@@ -1725,9 +1724,7 @@ class ServerArgs:
                 # likely due to some inefficiencies in torch allocator or our implementation.
                 # So we need to reserve more memory.
                 if decode_cuda_graph_config.max_bs > 300:
-                    reserved_mem += (
-                        decode_cuda_graph_config.max_bs * self.dp_size * 1.5
-                    )
+                    reserved_mem += decode_cuda_graph_config.max_bs * self.dp_size * 1.5
 
             # For piecewise cuda graphs
             if prefill_cuda_graph_config.backend != Backend.DISABLED:
@@ -2011,9 +2008,7 @@ class ServerArgs:
                         # DSACPLayerCommunicator does not all-reduce attention-TP
                         # partial o_proj outputs before replicated dense FFNs.
                         self.attn_cp_size = self.tp_size // self.dp_size
-                        self.cuda_graph_config.prefill[
-                            "backend"
-                        ] = Backend.DISABLED
+                        self.cuda_graph_config.prefill.backend = Backend.DISABLED
                         logger.warning(
                             f"Enable DSA Context Parallel opt, "
                             f"Setting dp_size == {self.dp_size} and "
@@ -3515,12 +3510,10 @@ class ServerArgs:
         else:
             num_tokens_per_bs = 1
         prefill_tokens = self.max_prefill_tokens
-        cg_config = self.cuda_graph_config or {}
-        prefill_cfg = cg_config.get(Phase.PREFILL) or {}
-        if prefill_cfg.get("backend") == Backend.TC_PIECEWISE:
-            prefill_tokens = max(prefill_tokens, prefill_cfg.get("max_bs") or 0)
-        decode_cfg = cg_config.get(Phase.DECODE) or {}
-        decode_max_bs = decode_cfg.get("max_bs") or 0
+        cg_config = self.cuda_graph_config
+        if cg_config is not None and cg_config.prefill.backend == Backend.TC_PIECEWISE:
+            prefill_tokens = max(prefill_tokens, cg_config.prefill.max_bs or 0)
+        decode_max_bs = (cg_config.decode.max_bs if cg_config is not None else 0) or 0
         decode_tokens = decode_max_bs * num_tokens_per_bs
         return max(prefill_tokens, decode_tokens)
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -214,9 +214,9 @@ class EAGLEWorker(TpModelWorker):
             self.draft_model_runner.model.set_embed_and_head(embed, head)
 
         # Init attention backend and cuda graphs
-        self.draft_model_runner.server_args.cuda_graph_config.decode[
-            "backend"
-        ] = backup_decode_mode
+        self.draft_model_runner.server_args.cuda_graph_config.decode.backend = (
+            backup_decode_mode
+        )
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -196,9 +196,9 @@ class EagleDraftWorker(BaseDraftWorker):
         self.init_lm_head()
 
         # Init attention backend and cuda graphs
-        self.draft_runner.server_args.cuda_graph_config.decode[
-            "backend"
-        ] = backup_decode_mode
+        self.draft_runner.server_args.cuda_graph_config.decode.backend = (
+            backup_decode_mode
+        )
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -34,7 +34,7 @@ from sglang.srt.layers.utils.logprob import add_output_logprobs_for_spec_v1
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
-from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -172,9 +172,9 @@ class FrozenKVMTPWorker(TpModelWorker):
         if hasattr(self.draft_model_runner.model, "bind_frozen_kv_context"):
             self._bind_kv_context()
 
-        self.draft_model_runner.server_args.cuda_graph_config.decode[
-            "backend"
-        ] = backup_decode_mode
+        self.draft_model_runner.server_args.cuda_graph_config.decode.backend = (
+            backup_decode_mode
+        )
 
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -176,9 +176,9 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
 
         # Init attention backend and cuda graphs
         for i in range(self.speculative_num_steps):
-            self.draft_runner_list[i].server_args.cuda_graph_config.decode[
-                "backend"
-            ] = backup_decode_mode
+            self.draft_runner_list[i].server_args.cuda_graph_config.decode.backend = (
+                backup_decode_mode
+            )
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
@@ -513,7 +513,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
             self.reset_cuda_graph_buffers(forward_batch, batch_result)
         else:
             logger.warning_once(
-                f"can't use cuda graph for draft extend! may have correctness issue!"
+                "can't use cuda graph for draft extend! may have correctness issue!"
             )
             select_index = (
                 torch.arange(len(batch.seq_lens), device=self.device)

--- a/python/sglang/srt/speculative/standalone_worker.py
+++ b/python/sglang/srt/speculative/standalone_worker.py
@@ -8,7 +8,7 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.managers.tp_worker import TpModelWorker
-from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -101,9 +101,9 @@ class StandaloneWorker(EAGLEWorker):
             )
 
         # Init attention backend and cuda graphs
-        self.draft_model_runner.server_args.cuda_graph_config.decode[
-            "backend"
-        ] = backup_decode_mode
+        self.draft_model_runner.server_args.cuda_graph_config.decode.backend = (
+            backup_decode_mode
+        )
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -7,7 +7,7 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.managers.tp_worker import TpModelWorker
-from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -113,9 +113,9 @@ class StandaloneDraftWorker(EagleDraftWorker):
         self.init_lm_head()
 
         # Init attention backend and cuda graphs
-        self.draft_runner.server_args.cuda_graph_config.decode[
-            "backend"
-        ] = backup_decode_mode
+        self.draft_runner.server_args.cuda_graph_config.decode.backend = (
+            backup_decode_mode
+        )
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )

--- a/test/registered/kv_canary/test_self_unit_capacities.py
+++ b/test/registered/kv_canary/test_self_unit_capacities.py
@@ -4,27 +4,24 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.kv_canary.capacities import CanaryLaunchCapacities
-from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=45, stage="extra-a", runner_config="1-gpu-small")
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestComputeLaunchCapacities(CustomTestCase):
     @staticmethod
     def _make_server_args(*, max_bs: int) -> SimpleNamespace:
-        # cg-refactor: ``cuda_graph_max_bs`` is now per-phase under
-        # ``cuda_graph_config[Phase.DECODE]['max_bs']``. Build the dict
-        # so ``CanaryLaunchCapacities.from_args`` reads the same value.
         return SimpleNamespace(
-            cuda_graph_config={
-                Phase.DECODE: {
-                    "backend": Backend.FULL,
-                    "max_bs": max_bs,
-                    "bs": None,
-                },
-            },
+            cuda_graph_config=CudaGraphConfig(
+                decode=PhaseConfig(backend=Backend.FULL, max_bs=max_bs)
+            ),
             speculative_num_draft_tokens=0,
             chunked_prefill_size=None,
             max_prefill_tokens=128,

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -3,10 +3,16 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
@@ -621,19 +627,63 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
             ServerArgs(**self._base_kwargs(kv_cache_dtype="fp4_e2m1"))
 
 
-class TestCutedslMoeMaxNumTokens(unittest.TestCase):
+class TestCudaGraphConfigDataclassAccess(CustomTestCase):
+    def test_overlap_force_cpu_seq_lens_with_tc_piecewise_prefill(self):
+        from sglang.srt.managers.overlap_utils import decide_needs_cpu_seq_lens
+
+        server_args = SimpleNamespace(
+            enable_two_batch_overlap=False,
+            cuda_graph_config=CudaGraphConfig(
+                prefill=PhaseConfig(backend=Backend.TC_PIECEWISE)
+            ),
+        )
+        attn_backend = SimpleNamespace(needs_cpu_seq_lens=False)
+
+        self.assertTrue(decide_needs_cpu_seq_lens(server_args, [attn_backend]))
+
+    @patch(
+        "sglang.srt.model_executor.cuda_graph_backend."
+        "tc_piecewise_cudagraph_backend.get_moe_a2a_backend"
+    )
+    def test_tc_piecewise_build_config_reads_phase_config_dataclass(
+        self, mock_get_moe_a2a_backend
+    ):
+        from sglang.srt.model_executor.cuda_graph_backend.tc_piecewise_cudagraph_backend import (
+            TcPiecewiseCudaGraphBackend,
+        )
+
+        mock_backend = mock_get_moe_a2a_backend.return_value
+        mock_backend.is_deepep.return_value = False
+        mock_backend.is_mooncake.return_value = False
+        server_args = SimpleNamespace(
+            cuda_graph_config=CudaGraphConfig(
+                prefill=PhaseConfig(
+                    backend=Backend.TC_PIECEWISE,
+                    bs=[32, 64],
+                    tc_compiler="eager",
+                )
+            ),
+            enable_torch_compile_debug_mode=False,
+        )
+
+        config = TcPiecewiseCudaGraphBackend.build_compilation_config(server_args)
+
+        self.assertEqual(config.get_capture_sizes(), [32, 64])
+        self.assertEqual(config.compiler, "eager")
+
+
+class TestCutedslMoeMaxNumTokens(CustomTestCase):
     """The shared CuteDSL MoE per-forward token bound. Fields are set directly
     to exercise the math independently of __post_init__ resolution.
 
     cg-refactor: the legacy ``disable_piecewise_cuda_graph`` /
     ``piecewise_cuda_graph_max_tokens`` / ``cuda_graph_max_bs`` fields were
     consolidated into ``cuda_graph_config``; the helper accepts the legacy
-    kwarg names for test readability and translates them to the per-phase dict.
+    kwarg names for test readability and translates them to the per-phase
+    dataclasses.
     """
 
     def _args(self, **overrides):
-        from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
-
         server_args = ServerArgs(model_path="dummy")
         fields = dict(
             speculative_algorithm=None,
@@ -649,21 +699,16 @@ class TestCutedslMoeMaxNumTokens(unittest.TestCase):
         cg_max_bs = fields.pop("cuda_graph_max_bs")
         for key, value in fields.items():
             setattr(server_args, key, value)
-        server_args.cuda_graph_config = {
-            Phase.DECODE: {
-                "backend": Backend.FULL,
-                "max_bs": cg_max_bs,
-                "bs": None,
-            },
-            Phase.PREFILL: {
-                "backend": (
+        server_args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(backend=Backend.FULL, max_bs=cg_max_bs),
+            prefill=PhaseConfig(
+                backend=(
                     Backend.DISABLED if disable_piecewise else Backend.TC_PIECEWISE
                 ),
-                "max_bs": piecewise_max,
-                "bs": None,
-                "tc_compiler": "eager",
-            },
-        }
+                max_bs=piecewise_max,
+                tc_compiler="eager",
+            ),
+        )
         return server_args
 
     def test_prefill_dominates_in_default_config(self):


### PR DESCRIPTION
## Summary

Fix remaining dict-style accesses to `CudaGraphConfig` / `PhaseConfig` after the cg-refactor dataclass migration.

This covers:
- default TC piecewise prefill config initialization
- overlap scheduler CPU seq-lens decision
- kv-canary capacity calculation
- CuteDSL MoE token budget calculation
- DSA CP / NPU config mutation paths
- speculative draft worker decode backend restore paths

The tests now use real `CudaGraphConfig` / `PhaseConfig` objects instead of dict mocks for the affected paths.

## Real Model Repro / Validation

### Baseline failure reproduced on H200

Environment:
- Host/container: `ion8-h200` / `sglang_bbuf`
- GPU: H200 GPU 7 (`CUDA_VISIBLE_DEVICES=7`)
- Repo path: `/home/sglang-omni/bbuf/repos/sglang-pr23906-codex`
- Baseline: original cg-refactor PR head before this fix (`c9edb97ad9`)
- Model: cached `Qwen3-0.6B`
  - `/root/.cache/huggingface/hub/models--Qwen--Qwen3-0.6B/snapshots/c1899de289a04d12100db370d81485cdf75e47ca`

Sanity check command confirming the PR branch has no dict `.get()` compatibility on `CudaGraphConfig`:

```bash
cd /home/sglang-omni/bbuf/repos/sglang-pr23906-codex
PYTHONPATH=python python3 - <<'PY'
from sglang.srt.model_executor.cuda_graph_config import CudaGraphConfig, Phase

cfg = CudaGraphConfig()
try:
    cfg.get(Phase.PREFILL)
except Exception as e:
    print(type(e).__name__, e)
PY
```

Output:

```text
AttributeError 'CudaGraphConfig' object has no attribute 'get'
```

Baseline real-model repro command:

```bash
cd /home/sglang-omni/bbuf/repos/sglang-pr23906-codex
CUDA_VISIBLE_DEVICES=7 PYTHONPATH=python timeout 240s python3 -m sglang.launch_server \
  --model-path /root/.cache/huggingface/hub/models--Qwen--Qwen3-0.6B/snapshots/c1899de289a04d12100db370d81485cdf75e47ca \
  --host 127.0.0.1 \
  --port 31008 \
  --tp-size 1 \
  --mem-fraction-static 0.70 \
  --trust-remote-code
```

The server successfully loaded the real model weights and completed decode CUDA graph capture, then failed when initializing default TC piecewise prefill CUDA graph:

```text
Capture piecewise CUDA graph begin.
Capture cuda graph num tokens [4, 8, 12, ..., 8192]
Scheduler hit an exception:
  File "python/sglang/srt/model_executor/cuda_graph_backend/tc_piecewise_cudagraph_backend.py", line 99, in build_compilation_config
    num_tokens = prefill["bs"]
TypeError: 'PhaseConfig' object is not subscriptable
```

This confirms the failure is not just a synthetic unit-test issue: the default real-model startup path reaches the migrated dataclass and crashes on the old dict-style access.

### Fixed build validated on H200

After applying this PR on top of current `Oasis-Git:cg-refactor`, I launched the same cached Qwen3-0.6B model on H200 GPU 7 with small graph shapes to keep the validation fast while still exercising both decode CUDA graph and TC piecewise prefill graph.

Exact validation script I ran:

```bash
cd /home/sglang-omni/bbuf/repos/sglang-pr23906-codex
LOG=/tmp/sglang_cg_refactor_fixed.log
rm -f "$LOG"
CUDA_VISIBLE_DEVICES=7 PYTHONPATH=python python3 -m sglang.launch_server \
  --model-path /root/.cache/huggingface/hub/models--Qwen--Qwen3-0.6B/snapshots/c1899de289a04d12100db370d81485cdf75e47ca \
  --host 127.0.0.1 \
  --port 31009 \
  --tp-size 1 \
  --mem-fraction-static 0.20 \
  --max-total-tokens 4096 \
  --cuda-graph-bs-decode 1 \
  --cuda-graph-tokens-prefill 4 \
  --trust-remote-code \
  > "$LOG" 2>&1 &
pid=$!
ready=0
for i in $(seq 1 180); do
  if curl -fsS http://127.0.0.1:31009/health >/dev/null 2>&1; then
    ready=1
    break
  fi
  if ! kill -0 "$pid" >/dev/null 2>&1; then
    break
  fi
  sleep 1
done
if [ "$ready" -eq 1 ]; then
  echo "SERVER_READY"
  curl -fsS -X POST http://127.0.0.1:31009/generate \
    -H "Content-Type: application/json" \
    -d '{"text":"hello","sampling_params":{"max_new_tokens":4,"temperature":0}}'
  echo
else
  echo "SERVER_NOT_READY"
fi
kill -TERM "$pid" >/dev/null 2>&1 || true
pkill -TERM -P "$pid" >/dev/null 2>&1 || true
sleep 2
kill -KILL "$pid" >/dev/null 2>&1 || true
pkill -KILL -P "$pid" >/dev/null 2>&1 || true
tail -n 160 "$LOG"
[ "$ready" -eq 1 ]
```

Key successful log points:

```text
Load weight end. type=Qwen3ForCausalLM
Capture cuda graph bs [1]
Capture cuda graph end.
Capture piecewise CUDA graph begin.
Capture cuda graph num tokens [4]
Compiling num tokens (num_tokens=4): 100%
Capturing num tokens (num_tokens=4 ...): 100%
Capture piecewise CUDA graph end.
Uvicorn running on http://127.0.0.1:31009
The server is fired up and ready to roll!
```

Health and generation results:

```text
SERVER_READY
/generate returned a successful 4-token response.
```

The server was terminated intentionally after validation.

## Tests

- `PYTHONPATH=python python3 test/registered/unit/server_args/test_server_args.py` on H200 container: 58 tests OK
- `PYTHONPATH=python python3 test/registered/kv_canary/test_self_unit_capacities.py` on H200 container: 4 tests OK
- local `python3 -m ruff check <changed files>`: passed
- local `git diff --check`: passed











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #26819201040](https://github.com/Oasis-Git/sglang/actions/runs/26819201040)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #26819200975](https://github.com/Oasis-Git/sglang/actions/runs/26819200975)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
